### PR TITLE
Set alterAssetTagGroups hook execution order

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ class HtmlWebpackEsmodulesPlugin {
       // Support newest and oldest version.
       if (HtmlWebpackPlugin.getHooks) {
         HtmlWebpackPlugin.getHooks(compilation).alterAssetTagGroups.tapAsync(
-          ID,
+          { name: ID, stage: Infinity },
           this.alterAssetTagGroups.bind(this, compiler)
         );
         if (this.outputMode === OUTPUT_MODES.MINIMAL) {
@@ -36,7 +36,7 @@ class HtmlWebpackEsmodulesPlugin {
         }
       } else {
         compilation.hooks.htmlWebpackPluginAlterAssetTags.tapAsync(
-          ID,
+          { name: ID, stage: Infinity },
           this.alterAssetTagGroups.bind(this, compiler)
         );
         if (this.outputMode === OUTPUT_MODES.MINIMAL) {


### PR DESCRIPTION
I'd encountered a problem when I was trying to use this plugin along with [webpack-subresource-integrity](https://github.com/waysact/webpack-subresource-integrity).

**What is the problem?**

Webpack SRI plugin calculates checksum of an asset an injects the result as `integrity` attribute of script tag.

Example:
```
<script src="/static/vendor.eaac3965496b959b.js" integrity="sha256-Bs/bCrmLJvAXuSFVnW93dhng0T7fs3y8Ysw9AcxWVPs= sha384-4EWpvbwSU3A0Paj0nnBFctWJRS0kRmdWwE6LFsVCxBtzegulmxcfQBp1cYngzFsr" crossorigin="anonymous"></script>
<script src="/static/app.3d38ff2b39dbe384.js" integrity="sha256-ZJ6xWagu9RgY0JfJZfq7y8KaSKvBUUe43q9Wdkmyps0= sha384-VfYJFI/3wx+edhGWxxfvKOBBcRmDR0UlOxR867htrvlf+e7WKRRgwtQ4oMfoNG/Q" crossorigin="anonymous"></script>
```

But in combination with module-nomodule-plugin I was having such situation:
```
<script type="module" src="/static/vendor.eaac3965496b959b.js" integrity="null" crossorigin="anonymous"></script>
<script type="module" src="/static/app.3d38ff2b39dbe384.js" integrity="null" crossorigin="anonymous"></script>
<script>(function(){var d=document;var c=d.createElement('script');if(!('noModule' in c)&&'onbeforeload' in c){var s=!1;d.addEventListener('beforeload',function(e){if(e.target===c){s=!0}else if(!e.target.hasAttribute('nomodule')||!s){return}e.preventDefault()},!0);c.type='module';c.src='.';d.head.appendChild(c);c.remove()}}())</script>
<script type="text/javascript" src="/static/vendor.b261dc8f941c040b.js" integrity="sha256-Bs6oPxvgKb1QBCKZU9mfVQ7vWqTQcF75bJT6R9h72Ws= sha384-pRSl1EUmup93gE2XdLyHsZZikMKLwhrVX7oMmsmJuqWStcFRdpxrLcM4htxm/3nS" crossorigin="anonymous" nomodule></script>
<script type="text/javascript" src="/static/app.575bdaab589f2013.js" integrity="sha256-ixVzZx0qIgGaH8hK3nuSKLjUWmLp/FtUim/xmn3n9LE= sha384-SyO/IIV8nvm+CgpXi+sEndKuApCxmhetwkGcsRlHZvxsel0/ypfpuvoI2QdetuPm" crossorigin="anonymous" nomodule></script>
```

So if you look carefully, the first two script tags have integrity value as `null`, which should not be.

**Why is this happen?**

This happens due to incorrect order of execution of `alterAssetTags` hook.
Both this plugin an SRI plugin rely on it (https://github.com/waysact/webpack-subresource-integrity/blob/master/index.js#L283).

Speaking shortly, on second iteration SRI plugin gets in body tags array some "redundant" tags, which come from first iteration but the don't have a precalculated intregrity.

**How I've fixed it?**

What we need to do is to change order of hook callbacks execution. In fact, `alterAssetTags` callback of this plugin must run at last, for we have to collect all tag changes by other plugins and then save it as temp assets.json.

This could be done by setting `stage` option. So, `stage: Infinity` tells the compilator to run this callback after all other registered `alterAssetTags` callbacks.

See https://github.com/webpack/tapable/issues/86#issuecomment-447925341