### PR TITLE
Keep initial chunks order in html file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -145,12 +145,11 @@ class HtmlWebpackEsmodulesPlugin {
       innerHTML: safariFixScript,
     }
 
-    body.push(safariFixScriptTag);
-    body.push(...existingAssets);
-
     // Make our array look like [modern, script, legacy]
     if (this.mode === 'legacy') {
-      body.reverse();
+      body.unshift(...existingAssets, safariFixScriptTag);
+    } else {
+      body.push(safariFixScriptTag, ...existingAssets);
     }
   }
 }


### PR DESCRIPTION
If I have more then one chunk to inject as script tag, resulting order is incorrect when using this plugin.

Initial situation:

I have chunks `app` and `vendor`. In rendered index.html I have
```
<script src="/static/vendor.955296247b84eb99.js"></script>
<script src="/static/app.06b7eb65543edd0d.js"></script>
```

Order of script is important, because browser needs to load and execute vendor chunk first in order to activate all of app dependencies.

But this plugin gives me the opposite situation:
```
<script type="module" src="/static/app.06b7eb65543edd0d.js"></script>
<script type="module" src="/static/vendor.955296247b84eb99.js"></script>
<script>(function(){var d=document;var c=d.createElement('script');if(!('noModule' in c)&&'onbeforeload' in c){var s=!1;d.addEventListener('beforeload',function(e){if(e.target===c){s=!0}else if(!e.target.hasAttribute('nomodule')||!s){return}e.preventDefault()},!0);c.type='module';c.src='.';d.head.appendChild(c);c.remove()}}())</script>
<script type="text/javascript" src="/static/app.b67badb3e3b31ae4.js" nomodule></script>
<script type="text/javascript" src="/static/vendor.f35bb36ecd491769.js" nomodule></script></body>
```

As you can see, the first in row is the `app` script and only then comes `vendor` script. That should not be.

My fix is to put *group* of chunks in the right order instead of reversing them.

So, if current mode is `legacy`, then in `existingAssets` we have `modern` scripts. Thus, we put modern scripts at the start, then safari fix. And last two elements of legacy scripts were already there.