### PR TITLE
Add crossorigin=anonymous attribute to module scripts

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,4 @@
-exports.loadScript = 'function $l(e,d,c){c=document.createElement("script"),"noModule" in c?(e && (c.src=e,c.type="module")):d && (c.src=d,c.async=true),c.src && document.head.appendChild(c)}';
+exports.loadScript = 'function $l(e,d,c){c=document.createElement("script"),"noModule" in c?(e && (c.src=e,c.type="module",c.crossOrigin="anonymous")):d && (c.src=d,c.async=true),c.src && document.head.appendChild(c)}';
 exports.safariFixScript = `(function(){var d=document;var c=d.createElement('script');if(!('noModule' in c)&&'onbeforeload' in c){var s=!1;d.addEventListener('beforeload',function(e){if(e.target===c){s=!0}else if(!e.target.hasAttribute('nomodule')||!s){return}e.preventDefault()},!0);c.type='module';c.src='.';d.head.appendChild(c);c.remove()}}())`;
 exports.ID = 'html-webpack-esmodules-plugin';
 exports.OUTPUT_MODES = {

--- a/src/index.js
+++ b/src/index.js
@@ -78,6 +78,7 @@ class HtmlWebpackEsmodulesPlugin {
         // Module in the new build
         newBody.forEach(a => {
           a.attributes.type = 'module';
+          a.attributes.crossOrigin = 'anonymous';
         });
       }
       // Write it!
@@ -96,6 +97,7 @@ class HtmlWebpackEsmodulesPlugin {
       body.forEach(tag => {
         if (tag.tagName === 'script' && tag.attributes) {
           tag.attributes.type = 'module';
+          tag.attributes.crossOrigin = 'anonymous';
         }
       });
     } else {


### PR DESCRIPTION
We had encountered a problem while using basic auth and modules in iOS. Scripts are not loading, console has CORS errors:

```
Blocked ….js from asking for credentials because it is a cross-origin request.
Blocked …js from asking for credentials because it is a cross-origin request.
….js Failed to load resource: the server responded with a status of 401 ()
….js Failed to load resource: the server responded with a status of 401 ()
```

Only iOS versions below 14 have this issue, desktop browsers or iOS14 are fine.  

According to the article https://jakearchibald.com/2017/es-modules-in-browsers/#no-credentials you can add a crossorigin attribute to module scripts, which will add credentials to same-origin requests in any browser that follows the old spec. It seems iOS versions below 14 follow the old spec.

  I have added `crossOrigin = 'anonymous'` attributes to the module scripts. Could you please have a look?

  Thank you!