### PR TITLE
Add support for Webpack 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,9 @@ This project relies on [html-webpack-plugin](https://github.com/jantimon/html-we
 
 ## How to use
 
-The only thing you need to do is return two build steps in your webpack and forward
-this to this plugin like this:
-
-- for legacy new WebpackModuleNomodulePlugin('legacy');
-- for modern new WebpackModuleNomodulePlugin('modern');
+1. Create separate build steps for your modern and legacy builds in your webpack config.  
+1. Each build step should include at least one use of the `html-webpack-plugin` with the `inject: 'body'` option set.
+1. Include this plugin with the name of the configuration in the constructor (e.g. `new WebpackModuleNomodulePlugin('legacy');` or `new WebpackModuleNomodulePlugin('modern');`)
 
 The rest will be handled for you!
 

--- a/package.json
+++ b/package.json
@@ -6,15 +6,12 @@
   "author": "Jovi De Croock <decroockjovi@gmail.com> (https://github.com/jovidecroock)",
   "main": "src/index.js",
   "scripts": {},
-  "devDependencies": {
-    "webpack": "^4.41.2"
-  },
   "dependencies": {
     "fs-extra": "9.0.1"
   },
   "peerDependencies": {
-    "html-webpack-plugin": "^3.0.0 || ^4.0.0",
-    "webpack": "^4.0.0"
+    "html-webpack-plugin": "^3.0.0 || ^4.0.0 || ^5.0.0",
+    "webpack": "^4.40.0 || ^5.0.0"
   },
   "keywords": [
     "webpack",

--- a/src/index.js
+++ b/src/index.js
@@ -83,17 +83,12 @@ class HtmlWebpackEsmodulesPlugin {
           a.attributes.crossOrigin = 'anonymous';
         });
       }
-      // Write it!
-      const assetContents = JSON.stringify(newBody);
-      fs.writeFileSync(tempFilename, assetContents);
-
       // Add the tempfile as an asset so that it will be transformed 
-      // in the PROCESS_ASSETS_STAGE_OPTIMIZE_HASH stage when true
-      // asset hashes are generated
+      // in the PROCESS_ASSETS_STAGE_OPTIMIZE_HASH stage when 
+      // "true asset hashes" are generated
       const { webpack } = compiler;
       const { RawSource } = webpack.sources;
-
-      compilation.emitAsset(assetName, new RawSource(assetContents));
+      compilation.emitAsset(assetName, new RawSource(JSON.stringify(newBody)));
       // Tell the compiler to continue.
       return cb();
     } 


### PR DESCRIPTION
Webpack 5 uses a technique called realContentHash that changes a file's hash after it has been processed by our plugin.  To fix this we can emit the temporary json file as an asset so that it gets updated with the new hashes.

See #25 for more information. 